### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/layout/intro_account.xml
+++ b/app/src/main/res/layout/intro_account.xml
@@ -17,7 +17,7 @@
         android:paddingLeft="32dp"
         android:paddingRight="32dp"
         android:text="@string/intro_title_opendns_account"
-        android:textColor="@android:color/white"
+        android:textColor="#282828"
         android:textSize="28sp"
         android:textStyle="bold" />
 
@@ -37,7 +37,7 @@
             android:layout_weight="0.9"
             android:gravity="center"
             android:text="@string/intro_account_main_text"
-            android:textColor="@android:color/white"
+            android:textColor="#282828"
             android:textSize="16sp" />
 
     </LinearLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,11 +6,13 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <item name="titleTextColor">#282828</item>
     </style>
 
     <style name="AppTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
+        <item name="titleTextColor">#282828</item>
     </style>
 
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />


### PR DESCRIPTION
The original text color of the component is '#FFFFFF', and the contrast between the text color ('#FFFFFF') and the background color ('#FF5722') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#282828') are as follows:
![image](https://user-images.githubusercontent.com/101503193/185450651-deefe89f-976f-4fc3-b351-0f7c5577f1ad.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.